### PR TITLE
Linux AArch64 wheel build support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,58 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@0.3.2
+
+jobs:
+  manylinux2014-aarch64:
+    parameters:
+      cibw_build:
+        type: string
+
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - run:
+          name: Build manylinux AArch64 wheel
+          command: |
+            docker run --rm \
+                -w /root/nrn \
+                -v $PWD:/root/nrn \
+                -v /opt/nrnwheel/mpt:/nrnwheel/mpt \
+                -e NEURON_NIGHTLY_TAG \
+                -e NRN_NIGHTLY_UPLOAD \
+                -e NRN_RELEASE_UPLOAD \
+                -e NEURON_WHEEL_VERSION \
+                -e NRN_BUILD_FOR_UPLOAD=1 \
+                'odidev/neuron_wheel' \
+                packaging/python/build_wheels.bash linux << parameters.cibw_build >> coreneuron
+      - store_artifacts:
+          path: ./wheelhouse
+          destination: artifacts
+
+workflows:
+  main:
+    jobs:
+      - manylinux2014-aarch64:
+          matrix:
+            parameters:
+              cibw_build: ["36", "37", "38", "39", "310"]
+          filters:
+            branches:
+              only:
+                - master
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - manylinux2014-aarch64:
+          matrix:
+            parameters:
+              cibw_build: ["36", "37", "38", "39", "310"]

--- a/packaging/python/Dockerfile.aarch64
+++ b/packaging/python/Dockerfile.aarch64
@@ -1,0 +1,62 @@
+FROM quay.io/pypa/manylinux2014_aarch64
+LABEL authors="Pramod Kumbhar, Fernando Pereira, Alexandru Savulescu"
+
+# install basic packages
+RUN yum -y install \
+    git \
+    wget \
+    make \
+    vim \
+    curl \
+    unzip \
+    bison \
+    flex \
+    autoconf \
+    automake \
+    openssh-server \
+    libtool
+
+WORKDIR /root
+
+RUN wget http://ftpmirror.gnu.org/ncurses/ncurses-6.2.tar.gz \
+    && tar -xvzf ncurses-6.2.tar.gz \
+    && cd ncurses-6.2  \
+    && ./configure --prefix=/nrnwheel/ncurses --without-shared CFLAGS="-fPIC" \
+    && make -j install
+
+RUN curl -L -o mpich-3.3.2.tar.gz http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz \
+    && tar -xvzf mpich-3.3.2.tar.gz \
+    && cd mpich-3.3.2 \
+    && export FFLAGS="-w -fallow-argument-mismatch -O2" \
+    && ./configure --prefix=/nrnwheel/mpich \
+    && make -j install
+
+RUN curl -L -o openmpi-4.0.3.tar.gz  https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.3.tar.gz \
+    && tar -xvzf openmpi-4.0.3.tar.gz \
+    && cd openmpi-4.0.3 \
+    && ./configure --prefix=/nrnwheel/openmpi \
+    && make -j install
+
+RUN curl -L -o readline-7.0.tar.gz https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz \
+    && tar -xvzf readline-7.0.tar.gz \
+    && cd readline-7.0  \
+    && ./configure --prefix=/nrnwheel/readline --disable-shared CFLAGS="-fPIC" \
+    && make -j install
+
+# create readline with ncurses
+RUN cd /nrnwheel/readline/lib \
+    && ar -x libreadline.a \
+    && ar -x ../../ncurses/lib/libncurses.a \
+    && ar cq libreadline.a *.o \
+    && rm *.o
+
+ENV PATH /nrnwheel/openmpi/bin:$PATH
+RUN yum -y install epel-release
+RUN yum -y install libX11-devel.aarch64 libXcomposite-devel.aarch64 vim-enhanced.aarch64
+RUN yum -y remove ncurses-devel
+
+# Copy Dockerfile for reference
+COPY Dockerfile.aarch64 .
+
+# build wheels from there
+WORKDIR /root


### PR DESCRIPTION
Owner: Madhukar
Fix: Add Linux AArch64 wheel build support
Build Logs: https://app.circleci.com/pipelines/github/odidev/nrn/10/workflows/cf843db0-0f9b-4ed2-a788-d0c0b4368fd0
Reviewers: Pruthvi and Disha

**Note:** Added circleci support to build Linux AArch64 wheel. So, to reviews the changes, you can take a reference of similar x86_64 azure pipeline job starting at https://github.com/neuronsimulator/nrn/blob/master/azure-pipelines.yml#L29
